### PR TITLE
Add interactive Q&A wizard to rcg init

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -32,6 +32,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
       - run: npm i
+      - run: npm run build
       - run: npm run cover
         if: github.event_name != 'pull_request'
       - run: npx nyc report --reporter=lcov

--- a/FUTURE.md
+++ b/FUTURE.md
@@ -2,36 +2,16 @@
 
 ### CLI
 
-After you have installed rcg, you can call its command-line with npx
+`npx rcg init` now asks which folder to put components in, which JS file extension to use, and
+whether to enable Next.js SASS module support, then writes the answers to rcg.config.js.
 
-```
-npx rcg init
-```
+Extending that wizard further would need these to be built first:
 
-This command will do the following:
-
--   Ask you which folder you want generated React components to be put in
--   Ask you what style you want React components to use (class, pure function)
--   Ask you what style library you want to use (sass, styled-components, css-in-js)
--   Ask you what testing library you want to use (jest, mocha, ava, enzyme, react-testing-library)
-
-It will then put these options in the rcg.config.js file.
-
-So, task breakdown...
-
--   Get the codebase generating code somehow
+-   Ask you what style you want React components to use (class, pure function) - not supported yet, generator only produces function components
+-   Ask you what style library you want to use (sass, styled-components, css-in-js) - not supported yet, generator only produces a SASS-style template
+-   Ask you what testing library you want to use (jest, mocha, ava, enzyme, react-testing-library) - not supported yet, generator only produces one generic jest/vitest-style test template
 
 ### Support for FELA styles
 
 Volvo Cars uses Fela in combination with their UI library vcc-ui. It would be good to be able to
 generate components that use FELA for the CSS, rather than SCSS.
-
-### Support for TypeScript
-
-Be able to generate the JS files as TypeScript files instead
-
-### Support for Prop Types
-
-Be able to generate components that have prop types specified for them
-
-e.g. --props title:string description:string available:boolean

--- a/README.md
+++ b/README.md
@@ -159,6 +159,16 @@ You can create an rcg.config.js file by running this command:
 npx rcg init
 ```
 
+This will ask you a few questions (which folder to generate components in, which JS file extension to use, and whether to use Next.js SASS module support) and write the answers to an rcg.config.js file.
+
+To skip the questions and generate the file with default values (useful in CI or scripts), pass the `--yes` flag:
+
+```
+npx rcg init --yes
+```
+
+If an rcg.config.js file already exists, you'll be asked to confirm before it gets overwritten (running with `--yes` will overwrite it without asking).
+
 ### Running Tests
 
 ```

--- a/bin/rcg
+++ b/bin/rcg
@@ -4,7 +4,7 @@ import path from "path";
 import { createRequire } from "module";
 import { program } from "commander";
 import loadConfigFileIfExists from "../dist/lib/helpers/loadConfigFile.js";
-import { createExampleConfigFile } from "../dist/lib/helpers/generateConfigFile.js";
+import { runInit } from "../dist/lib/helpers/generateConfigFile.js";
 import generateComponent from "../dist/index.js";
 
 const require = createRequire(import.meta.url);
@@ -84,8 +84,13 @@ program
   .arguments("<componentName>")
   .action(mainAction)
   .command("init")
-  .description("Create an example rcg.config.js file")
-  .action(createExampleConfigFile);
+  .description("Create an rcg.config.js file, via an interactive Q&A")
+  .option(
+    "-y, --yes",
+    "skip the interactive prompts and use default values",
+    false,
+  )
+  .action((options) => runInit({ yes: options.yes }));
 
 // Run the command
 program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.27",
 			"license": "MIT",
 			"dependencies": {
+				"@inquirer/prompts": "^8.6.0",
 				"commander": "^15.0.0",
 				"to-case": "^2.0.0"
 			},
@@ -262,6 +263,334 @@
 			],
 			"engines": {
 				"node": ">=14.21.3"
+			}
+		},
+		"node_modules/@inquirer/ansi": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.7.tgz",
+			"integrity": "sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/checkbox": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-5.2.2.tgz",
+			"integrity": "sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/confirm": {
+			"version": "6.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-6.2.0.tgz",
+			"integrity": "sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/core": {
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/core/-/core-12.0.0.tgz",
+			"integrity": "sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.0.7",
+				"cli-width": "^4.1.0",
+				"fast-wrap-ansi": "^0.2.0",
+				"mute-stream": "^3.0.0",
+				"signal-exit": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/editor": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-5.3.0.tgz",
+			"integrity": "sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/external-editor": "^3.0.4",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/expand": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-5.1.2.tgz",
+			"integrity": "sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/external-editor": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/@inquirer/external-editor/-/external-editor-3.0.4.tgz",
+			"integrity": "sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==",
+			"license": "MIT",
+			"dependencies": {
+				"chardet": "^2.1.1",
+				"iconv-lite": "^0.7.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/figures": {
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.8.tgz",
+			"integrity": "sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			}
+		},
+		"node_modules/@inquirer/input": {
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.1.3.tgz",
+			"integrity": "sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/number": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/number/-/number-4.2.0.tgz",
+			"integrity": "sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/password": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/password/-/password-5.1.2.tgz",
+			"integrity": "sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/prompts": {
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.6.0.tgz",
+			"integrity": "sha512-WgBVDRy3IQ4v9XMCpQ1YDGpso2PcMUxYJzZdH4Nt4t0eoXhEPmOCh5iZbXbR4GTbdUB9VPWBbJB12rkjbaGDCw==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/checkbox": "^5.2.2",
+				"@inquirer/confirm": "^6.2.0",
+				"@inquirer/editor": "^5.3.0",
+				"@inquirer/expand": "^5.1.2",
+				"@inquirer/input": "^5.1.3",
+				"@inquirer/number": "^4.2.0",
+				"@inquirer/password": "^5.1.2",
+				"@inquirer/rawlist": "^5.3.2",
+				"@inquirer/search": "^4.3.0",
+				"@inquirer/select": "^5.2.2"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/rawlist": {
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-5.3.2.tgz",
+			"integrity": "sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/search": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@inquirer/search/-/search-4.3.0.tgz",
+			"integrity": "sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/select": {
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@inquirer/select/-/select-5.2.2.tgz",
+			"integrity": "sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==",
+			"license": "MIT",
+			"dependencies": {
+				"@inquirer/ansi": "^2.0.7",
+				"@inquirer/core": "^12.0.0",
+				"@inquirer/figures": "^2.0.8",
+				"@inquirer/type": "^4.0.7"
+			},
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@inquirer/type": {
+			"version": "4.0.7",
+			"resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.7.tgz",
+			"integrity": "sha512-t28inv14nMQ1PhKpsJPY+kEs/c00qzeCOS2gTNRyTjG5d6qsVA2fItxW4hkvGZ5lvanGLdtCzVIx5dwdRpN1+g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=23.5.0 || ^22.13.0 || ^20.17.0"
+			},
+			"peerDependencies": {
+				"@types/node": ">=18"
+			},
+			"peerDependenciesMeta": {
+				"@types/node": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@jridgewell/resolve-uri": {
@@ -647,7 +976,7 @@
 			"version": "26.2.0",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
 			"integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~8.3.0"
@@ -1179,6 +1508,12 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/chardet": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+			"integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
+			"license": "MIT"
+		},
 		"node_modules/chokidar": {
 			"version": "4.0.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
@@ -1193,6 +1528,15 @@
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/cli-width": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+			"integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/commander": {
@@ -1251,6 +1595,30 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12.0.0"
+			}
+		},
+		"node_modules/fast-string-truncated-width": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
+			"integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
+			"license": "MIT"
+		},
+		"node_modules/fast-string-width": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
+			"integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-truncated-width": "^3.0.2"
+			}
+		},
+		"node_modules/fast-wrap-ansi": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.2.tgz",
+			"integrity": "sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==",
+			"license": "MIT",
+			"dependencies": {
+				"fast-string-width": "^3.0.2"
 			}
 		},
 		"node_modules/fdir": {
@@ -1330,6 +1698,22 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/typicode"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+			"integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -1722,6 +2106,15 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/mute-stream": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-3.0.0.tgz",
+			"integrity": "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==",
+			"license": "ISC",
+			"engines": {
+				"node": "^20.17.0 || >=22.9.0"
+			}
+		},
 		"node_modules/nanoid": {
 			"version": "5.1.16",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.16.tgz",
@@ -1930,6 +2323,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"license": "MIT"
+		},
 		"node_modules/semver": {
 			"version": "7.8.5",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1949,6 +2348,18 @@
 			"integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/signal-exit": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+			"license": "ISC",
+			"engines": {
+				"node": ">=14"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
 		},
 		"node_modules/size-limit": {
 			"version": "13.0.3",
@@ -2259,7 +2670,7 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
 			"integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
-			"dev": true,
+			"devOptional": true,
 			"license": "MIT"
 		},
 		"node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"vitest": "^4.1.0"
 	},
 	"dependencies": {
+		"@inquirer/prompts": "^8.6.0",
 		"commander": "^15.0.0",
 		"to-case": "^2.0.0"
 	},

--- a/scripts/generateConfigFile.ts
+++ b/scripts/generateConfigFile.ts
@@ -1,5 +1,5 @@
-import { createExampleConfigFile } from "../src/lib/helpers/generateConfigFile.ts";
+import { runInit } from "../dist/lib/helpers/generateConfigFile.js";
 
 (async () => {
-	await createExampleConfigFile();
+	await runInit({ yes: true });
 })();

--- a/src/lib/helpers/generateConfigFile.ts
+++ b/src/lib/helpers/generateConfigFile.ts
@@ -1,17 +1,80 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
+import { confirm } from "@inquirer/prompts";
+import promptForConfig, { type ConfigAnswers } from "./promptForConfig.js";
 
 const exampleConfigFilePath = path.join(process.cwd(), "rcg.config.js");
 
-const createExampleConfigFile = async (): Promise<void> => {
-	const exampleConfig = `import { join } from 'path';
-export default {
-	directory: join(process.cwd(), 'components'),
-	jsExtension: 'js',
-};
-`;
-	console.log("Creating example config file at", exampleConfigFilePath);
-	await fs.writeFile(exampleConfigFilePath, exampleConfig);
+const defaultAnswers: ConfigAnswers = {
+	directory: "components",
+	jsExtension: "js",
+	cssExtension: "scss",
+	nextjsSassSupport: false,
 };
 
-export { createExampleConfigFile, exampleConfigFilePath };
+const buildConfigFileContent = (answers: ConfigAnswers): string => {
+	return `import { join } from 'path';
+
+export default {
+	directory: join(process.cwd(), '${answers.directory}'),
+	jsExtension: '${answers.jsExtension}',
+	cssExtension: '${answers.cssExtension}',
+	nextjsSassSupport: ${answers.nextjsSassSupport},
+};
+`;
+};
+
+const configFileExists = async (): Promise<boolean> => {
+	try {
+		await fs.access(exampleConfigFilePath);
+		return true;
+	} catch {
+		return false;
+	}
+};
+
+interface RunInitOptions {
+	yes?: boolean;
+}
+
+const runInit = async ({ yes }: RunInitOptions = {}): Promise<void> => {
+	const interactive = !yes && Boolean(process.stdin.isTTY);
+	const exists = await configFileExists();
+
+	try {
+		if (exists) {
+			if (interactive) {
+				const shouldOverwrite = await confirm({
+					message: `${exampleConfigFilePath} already exists. Overwrite it?`,
+					default: false,
+				});
+				if (!shouldOverwrite) {
+					console.log("Skipped creating rcg.config.js");
+					return;
+				}
+			} else {
+				console.log(
+					`Overwriting existing config file at ${exampleConfigFilePath}`,
+				);
+			}
+		}
+
+		const answers = interactive ? await promptForConfig() : defaultAnswers;
+		console.log("Creating config file at", exampleConfigFilePath);
+		await fs.writeFile(exampleConfigFilePath, buildConfigFileContent(answers));
+	} catch (error) {
+		if (error instanceof Error && error.name === "ExitPromptError") {
+			console.log("\nCancelled.");
+			process.exitCode = 1;
+			return;
+		}
+		throw error;
+	}
+};
+
+export {
+	buildConfigFileContent,
+	defaultAnswers,
+	exampleConfigFilePath,
+	runInit,
+};

--- a/src/lib/helpers/promptForConfig.ts
+++ b/src/lib/helpers/promptForConfig.ts
@@ -1,0 +1,39 @@
+import { confirm, input, select } from "@inquirer/prompts";
+
+interface ConfigAnswers {
+	directory: string;
+	jsExtension: string;
+	cssExtension: string;
+	nextjsSassSupport: boolean;
+}
+
+const promptForConfig = async (): Promise<ConfigAnswers> => {
+	const directory = await input({
+		message: "Which folder should generated components go in?",
+		default: "components",
+	});
+	const jsExtension = await select({
+		message: "Which file extension should components use?",
+		choices: [
+			{ name: "js", value: "js" },
+			{ name: "jsx", value: "jsx" },
+			{ name: "ts", value: "ts" },
+			{ name: "tsx", value: "tsx" },
+		],
+		default: "js",
+	});
+	const nextjsSassSupport = await confirm({
+		message: "Enable Next.js built-in SASS module support?",
+		default: false,
+	});
+	const cssExtension = nextjsSassSupport
+		? "scss"
+		: await input({
+				message: "Which extension should style files use?",
+				default: "scss",
+			});
+	return { directory, jsExtension, cssExtension, nextjsSassSupport };
+};
+
+export default promptForConfig;
+export type { ConfigAnswers };

--- a/test/bin/rcg.test.ts
+++ b/test/bin/rcg.test.ts
@@ -10,8 +10,8 @@ import {
 	it,
 } from "vitest";
 import {
-	createExampleConfigFile,
 	exampleConfigFilePath,
+	runInit,
 } from "../../dist/lib/helpers/generateConfigFile.js";
 import { version } from "../../package.json";
 import { exec, exists, readdir, readFile, unlink } from "../helpers";
@@ -89,7 +89,7 @@ describe("rcg binary", () => {
 
 		beforeAll(async () => {
 			seed(["components"]);
-			await createExampleConfigFile();
+			await runInit({ yes: true });
 			const { stdout, stderr } = await exec(command);
 			recordedStdout = stdout;
 			recordedStderr = stderr;

--- a/test/lib/helpers/generateConfigFile.test.ts
+++ b/test/lib/helpers/generateConfigFile.test.ts
@@ -1,0 +1,134 @@
+import assert from "assert";
+import { afterEach, beforeEach, describe, it, vi } from "vitest";
+import { exists, readFile, unlink } from "../../helpers";
+
+vi.mock("@inquirer/prompts", () => ({
+	confirm: vi.fn(),
+	input: vi.fn(),
+	select: vi.fn(),
+}));
+
+const { confirm, input, select } = await import("@inquirer/prompts");
+const {
+	buildConfigFileContent,
+	defaultAnswers,
+	exampleConfigFilePath,
+	runInit,
+} = await import("../../../dist/lib/helpers/generateConfigFile.js");
+
+const setTTY = (isTTY: boolean): void => {
+	Object.defineProperty(process.stdin, "isTTY", {
+		value: isTTY,
+		configurable: true,
+	});
+};
+
+describe("buildConfigFileContent", () => {
+	it("should build the config file content from the given answers", () => {
+		const content = buildConfigFileContent({
+			directory: "pages",
+			jsExtension: "tsx",
+			cssExtension: "module.scss",
+			nextjsSassSupport: true,
+		});
+		assert(content.includes("directory: join(process.cwd(), 'pages')"));
+		assert(content.includes("jsExtension: 'tsx'"));
+		assert(content.includes("cssExtension: 'module.scss'"));
+		assert(content.includes("nextjsSassSupport: true"));
+	});
+});
+
+describe("runInit", () => {
+	const originalIsTTY = process.stdin.isTTY;
+
+	beforeEach(() => {
+		vi.mocked(confirm).mockReset();
+		vi.mocked(input).mockReset();
+		vi.mocked(select).mockReset();
+	});
+
+	afterEach(async () => {
+		setTTY(originalIsTTY);
+		if (await exists(exampleConfigFilePath))
+			await unlink(exampleConfigFilePath);
+	});
+
+	it("should write the default config and skip prompts when yes is true", async () => {
+		setTTY(true);
+		await runInit({ yes: true });
+		assert(await exists(exampleConfigFilePath));
+		const content = await readFile(exampleConfigFilePath);
+		assert.equal(content, buildConfigFileContent(defaultAnswers));
+		assert(!vi.mocked(confirm).mock.calls.length);
+		assert(!vi.mocked(input).mock.calls.length);
+		assert(!vi.mocked(select).mock.calls.length);
+	});
+
+	it("should write the default config and skip prompts when not running in a TTY", async () => {
+		setTTY(false);
+		await runInit({});
+		assert(await exists(exampleConfigFilePath));
+		const content = await readFile(exampleConfigFilePath);
+		assert.equal(content, buildConfigFileContent(defaultAnswers));
+		assert(!vi.mocked(input).mock.calls.length);
+	});
+
+	it("should prompt for answers and write them when running interactively", async () => {
+		setTTY(true);
+		vi.mocked(input)
+			.mockResolvedValueOnce("pages")
+			.mockResolvedValueOnce("css");
+		vi.mocked(select).mockResolvedValueOnce("tsx");
+		vi.mocked(confirm).mockResolvedValueOnce(false);
+
+		await runInit({});
+
+		const content = await readFile(exampleConfigFilePath);
+		assert.equal(
+			content,
+			buildConfigFileContent({
+				directory: "pages",
+				jsExtension: "tsx",
+				cssExtension: "css",
+				nextjsSassSupport: false,
+			}),
+		);
+	});
+
+	it("should ask to overwrite an existing config file, and skip writing when declined", async () => {
+		setTTY(true);
+		await runInit({ yes: true });
+		const originalContent = await readFile(exampleConfigFilePath);
+
+		vi.mocked(confirm).mockResolvedValueOnce(false);
+		await runInit({});
+
+		const content = await readFile(exampleConfigFilePath);
+		assert.equal(content, originalContent);
+		assert(!vi.mocked(input).mock.calls.length);
+	});
+
+	it("should overwrite an existing config file when accepted", async () => {
+		setTTY(true);
+		await runInit({ yes: true });
+
+		vi.mocked(confirm)
+			.mockResolvedValueOnce(true) // overwrite confirmation
+			.mockResolvedValueOnce(true); // nextjsSassSupport
+		vi.mocked(input).mockResolvedValueOnce("pages");
+		vi.mocked(select).mockResolvedValueOnce("jsx");
+
+		await runInit({});
+
+		const content = await readFile(exampleConfigFilePath);
+		assert.equal(
+			content,
+			buildConfigFileContent({
+				directory: "pages",
+				jsExtension: "jsx",
+				cssExtension: "scss",
+				nextjsSassSupport: true,
+			}),
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- `npx rcg init` now runs an interactive Q&A wizard (directory, JS extension, Next.js SASS support, CSS extension) instead of writing a static template, using `@inquirer/prompts`.
- Falls back to sensible defaults automatically when `--yes` is passed or stdin isn't a TTY (CI/scripts), so it never hangs waiting for input.
- Confirms before overwriting an existing `rcg.config.js` when running interactively; overwrites with a console note otherwise.
- Handles Ctrl+C (`ExitPromptError`) gracefully with a "Cancelled." message instead of a stack trace.

## Test plan
- [x] `npm t` (tsc + full vitest suite) passes, 37/37 tests
- [x] New unit tests for `buildConfigFileContent` and all `runInit` branches (yes-mode, non-TTY fallback, interactive answers, overwrite accept/decline) via mocked `@inquirer/prompts`
- [x] Manually smoke-tested `rcg init --yes` and `rcg init` in a non-TTY shell
- [x] Manually smoke-tested the interactive wizard under a real pty (`script`), including the Ctrl+C cancellation path
- [x] `npx @biomejs/biome check .` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)